### PR TITLE
README: update config details

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,5 +51,10 @@ Configure
     Configure wikipedia.py - Sopel Wikipedia Plugin
     Enter the default language to find articles from. [en]
 
-The [bot database](https://sopel.chat/docs/package/db) also supports the
-per-nick (for PMs) and per-channel value `wikipedia_lang`.
+Chanops and bot admins can override the default language on a per-channel basis with
+the ``.wpclang`` command.
+
+Users can also configure a preferred language for Wikipedia lookups using the
+``.wplang`` command.
+
+*At this time, there are no configuration settings for the* ``wiktionary`` *plugin.*


### PR DESCRIPTION
I came to fix the Markdown-hyperlink-in-rST problem, then realized that talking about what the bot's DB does is actually irrelevant to the user. The config commands usable on IRC should be documented, not the mechanism by which they work.

### Mild annoyance

Working on this little patch reminded me why I usually go for Markdown readmes:

<img width="555" height="74" alt="image" src="https://github.com/user-attachments/assets/1b534372-379e-4684-b0ca-f8f618804bc3" />

rST doesn't support nesting inline markup. 🤦‍♂️